### PR TITLE
Compile fixes

### DIFF
--- a/backend/src/Makefile.am
+++ b/backend/src/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-backend_bindir = /usr/lib/cups/backend
+backend_bindir = /usr/libexec/cups/backend
 backend_bin_PROGRAMS = cnijusb
 transform =
 

--- a/backendnet/backend/Makefile.am
+++ b/backendnet/backend/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-backendnet_bindir = /usr/lib/cups/backend
+backendnet_bindir = /usr/libexec/cups/backend
 backendnet_bin_PROGRAMS = cnijnet
 transform =
 

--- a/backendnet/configure.ac
+++ b/backendnet/configure.ac
@@ -25,7 +25,11 @@ fi
 AC_DEFINE_UNQUOTED([BJLIB_PATH], ["${enable_libpath}"], [BJLIB_PATH])
 AC_SUBST(BJLIB_PATH)
 
-ARC=`getconf LONG_BIT`
+case "$ABI" in
+    x86) ARC=32;;
+    amd64) ARC=64;;
+    *) ARC=`getconf LONG_BIT`;;
+esac
 AC_SUBST(ARC)
 
 # Checks for programs.

--- a/cngpijmon/cnijnpr/cnijnpr/cnijnpr.c
+++ b/cngpijmon/cnijnpr/cnijnpr/cnijnpr.c
@@ -35,6 +35,8 @@
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <sys/sysctl.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <config.h>
 #include <fcntl.h>
 

--- a/cngpijmon/cnijnpr/configure.ac
+++ b/cngpijmon/cnijnpr/configure.ac
@@ -39,7 +39,11 @@ AC_CHECK_FUNCS([memset socket strdup strrchr])
 
 CFLAGS="-O2"
 
-ARC=`getconf LONG_BIT`
+case "$ABI" in
+    x86) ARC=32;;
+    amd64) ARC=64;;
+    *) ARC=`getconf LONG_BIT`;;
+esac
 AC_SUBST(ARC)
 
 AC_CONFIG_FILES([Makefile

--- a/cngpijmon/src/bjcupsmon_cups.c
+++ b/cngpijmon/src/bjcupsmon_cups.c
@@ -21,6 +21,7 @@
 #include <cups/cups.h>
 #include <cups/ppd.h>
 #include <cups/language.h>
+#include <cups/ppd.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <pwd.h>

--- a/cnijfilter/configure.ac
+++ b/cnijfilter/configure.ac
@@ -50,7 +50,11 @@ case "${program_suffix}" in
 esac
 AC_SUBST(CNCL_LIB_ID)
 
-ARC=`getconf LONG_BIT`
+case "$ABI" in
+    x86) ARC=32;;
+    amd64) ARC=64;;
+    *) ARC=`getconf LONG_BIT`;;
+esac
 AC_SUBST(ARC)
 
 AC_PROG_CC

--- a/cnijfilter/src/bjfimage.c
+++ b/cnijfilter/src/bjfimage.c
@@ -948,8 +948,8 @@ static short ppm_image_init( LPBJF_IMAGEINFO lpbjfimage )
 	short			tmpformat;
 	short			retbyte = 0;
 	short			bpp = 3;
-	long			width = 0;
-	long			length = 0;
+	png_uint_32		width = 0;
+	png_uint_32		length = 0;
 	long			maxvalue = 0;
 	long			rstep = 0;
 	long			RasterLength = 0;

--- a/lgmon/configure.ac
+++ b/lgmon/configure.ac
@@ -52,7 +52,11 @@ case "${program_suffix}" in
 esac
 AC_SUBST(CNCL_LIB_ID)
 
-ARC=`getconf LONG_BIT`
+case "$ABI" in
+    x86) ARC=32;;
+    amd64) ARC=64;;
+    *) ARC=`getconf LONG_BIT`;;
+esac
 AC_SUBST(ARC)
 
 AC_PROG_CC

--- a/maintenance/configure.ac
+++ b/maintenance/configure.ac
@@ -116,7 +116,11 @@ CFLAGS="-O2 -Wall"
 XML2_CFLAGS=`xml2-config --cflags`
 AC_SUBST(XML2_CFLAGS)
 
-ARC=`getconf LONG_BIT`
+case "$ABI" in
+    x86) ARC=32;;
+    amd64) ARC=64;;
+    *) ARC=`getconf LONG_BIT`;;
+esac
 AC_SUBST(ARC)
 
 AC_CONFIG_FILES([

--- a/pstocanonij/filter/Makefile.am
+++ b/pstocanonij/filter/Makefile.am
@@ -1,4 +1,4 @@
-filterdir=$(libdir)/cups/filter
+filterdir=$(libexecdir)/cups/filter
 
 filter_PROGRAMS= pstocanonij
 


### PR DESCRIPTION
Hi, it seems a few things remain unfixed--mainly including standard headers in order to compile the whole package. Additionnaly, there is an ABI x86_32 fix in case of cross compiling or when using x86 ABI on amd64 architecture. The others tiny fixes relate to installation linked to distribution.

If you don't need any of the patch, I can pretty much remove any or all of theme.
Thanks for sharing this.